### PR TITLE
feat: Standardizing Pet Labels

### DIFF
--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -4,6 +4,7 @@ import HomeDetails from '../src/components/HomeDetails'
 import Footer from '../src/components/Footer'
 import { useEffect, useState } from 'react'
 import petServices from '../src/services/pet.services'
+import { getLabelColorBasedOnStatus } from '../src/utils/getLabelColorBasedOnStatus'
 
 export default function Home() {
     function redirectToHome() {
@@ -99,9 +100,17 @@ export default function Home() {
                                         </div>
 
                                         <div className="text">
-                                            <p>{pets.name}</p>
-                                            <p>{pets.createdAt}</p>
-                                            <p>{pets.locale}</p>
+                                            <p style={{backgroundColor: "#a3a3a3"}} >
+                                                {pets.name}
+                                            </p>
+                                            
+                                            <p style={{backgroundColor: getLabelColorBasedOnStatus(pets.status)}} >
+                                                {pets.status} - {pets.createdAt}
+                                            </p>
+
+                                            <p>
+                                                {pets.locale}
+                                            </p>
                                         </div>
                                     </div>
                                 </a>

--- a/pages/pets.jsx
+++ b/pages/pets.jsx
@@ -4,6 +4,7 @@ import petServices from '../src/services/pet.services'
 import Navigation from '../src/components/Navigation'
 import Footer from '../src/components/Footer'
 import Head from 'next/head'
+import { getLabelColorBasedOnStatus } from '../src/utils/getLabelColorBasedOnStatus'
 
 const pets = () => {
 
@@ -79,9 +80,17 @@ const pets = () => {
                                     </div>
 
                                     <div className="text">
-                                        <p>{pets.name}</p>
-                                        <p>{pets.status}</p>
-                                        <p>{pets.locale}</p>
+                                        <p style={{backgroundColor: "#a3a3a3"}}>
+                                            {pets.name}
+                                        </p>
+
+                                        <p style={{backgroundColor: getLabelColorBasedOnStatus(pets.status)}}>
+                                            {pets.status} - {pets.createdAt}
+                                        </p>
+                                        
+                                        <p>
+                                            {pets.locale}
+                                        </p>
                                     </div>
                                 </div>
                             </a>

--- a/src/utils/getLabelColorBasedOnStatus.js
+++ b/src/utils/getLabelColorBasedOnStatus.js
@@ -1,0 +1,9 @@
+export function getLabelColorBasedOnStatus(status) {
+    const statusLabelColor = {
+        'Perdido': '#DC2828',
+        'Encontrado': '#3370d4',
+        'Adoção': 'orange',
+    };
+
+    return statusLabelColor[status] ?? "#75BEA2";
+}


### PR DESCRIPTION

# Descrição

Este Pull request propõe padronizar a cor das tags do componente pet por situação. Dessa forma fica mais fácil identificar a situação de cada pet. Também propus deixar a label do nome em cinza, e a localização continuar em verde para assim melhor identificar cada label.

## Algumas Screenshots da melhoria

![image](https://github.com/Yagasaki7K/website-findyourpet/assets/40901963/64f2b87f-c7f5-42b9-8b1b-228d280064a2)

![image](https://github.com/Yagasaki7K/website-findyourpet/assets/40901963/04ac2821-1599-4bdf-b3eb-05da5df7c8b7)


## Tipo de mudança

- [ x ] Refatoração

# Como Reproduzir as mudanças?

Para reproduzir as mudanças siga os seguintes passos:

1. Reporte um animal para cada status e veja que para o status encontrado a label é Azul, para o Perdido vermelha e para adoção o Laranja.
2. Perceba que na tanto na página inicial quanto na página de achados e perdidos o nome dos pets está em cinza.
