### PR TITLE
perf: Next.js image, font, cache & fetch optimizations

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+	const response = NextResponse.next();
+	const pathname = request.nextUrl.pathname;
+
+	if (pathname.startsWith("/_next/static") || pathname.startsWith("/images") || /\.(png|jpg|jpeg|webp|avif|svg|ico)$/.test(pathname)) {
+		response.headers.set("Cache-Control", "public, max-age=31536000, immutable");
+	} else if (!pathname.startsWith("/api")) {
+		response.headers.set("Cache-Control", "public, s-maxage=300, stale-while-revalidate=86400");
+	}
+
+	return response;
+}
+
+export const config = {
+	matcher: ["/((?!api|_next/image|favicon.ico).*)"],
+};

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,12 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	reactStrictMode: true,
+	images: {
+		formats: ["image/avif", "image/webp"],
+		remotePatterns: [
+			{ protocol: "https", hostname: "**" },
+		],
+	},
 };
 
 module.exports = nextConfig;

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,7 +1,14 @@
 import Head from "next/head";
+import { Poppins } from "next/font/google";
 import { Toaster } from "sonner";
 import "../styles/globals.css";
 import SEO from "../next-seo.config";
+
+const poppins = Poppins({
+	weight: ["300", "400", "500", "600", "700"],
+	subsets: ["latin"],
+	display: "swap",
+});
 
 function MyApp({ Component, pageProps }) {
 	const defaultOgImage = SEO?.openGraph?.images?.[0];
@@ -33,7 +40,9 @@ function MyApp({ Component, pageProps }) {
 				{SEO.twitter?.handle && <meta name="twitter:creator" content={SEO.twitter.handle} />}
 				{SEO.twitter?.site && <meta name="twitter:site" content={SEO.twitter.site} />}
 			</Head>
-			<Component {...pageProps} />
+			<main className={poppins.className}>
+				<Component {...pageProps} />
+			</main>
 			<Toaster richColors position="top-right" />
 		</>
 	);

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Image from "next/image";
 import Navigation from "../src/components/Navigation";
 import HomeDetails from "../src/components/HomeDetails";
 import Footer from "../src/components/Footer";
@@ -16,14 +17,24 @@ export default function Home() {
 	}
 
 	const [Pets, setPets] = useState([]);
+	const PETS_CACHE_KEY = "home-pets-cache-v1";
 
 	useEffect(() => {
 		getPets();
 	}, []);
 
 	async function getPets() {
+		const cached = typeof window !== "undefined" ? sessionStorage.getItem(PETS_CACHE_KEY) : null;
+		if (cached) {
+			setPets(JSON.parse(cached));
+		}
+
 		const data = await petServices.getAllPets();
-		setPets(data.docs.map((doc) => ({ ...doc.data(), id: doc.id })));
+		const mappedPets = data.docs.map((doc) => ({ ...doc.data(), id: doc.id }));
+		setPets(mappedPets);
+		if (typeof window !== "undefined") {
+			sessionStorage.setItem(PETS_CACHE_KEY, JSON.stringify(mappedPets));
+		}
 	}
 
 	return (
@@ -72,13 +83,13 @@ export default function Home() {
 						</div>
 					</div>
 					<div className="rightContent">
-						<img src="/dog.png" alt="" />
+						<Image src="/dog.png" alt="" width={800} height={800} priority sizes="(max-width: 768px) 0px, 50vw" />
 					</div>
 				</div>
 
 				<div className="howWorks" id="howWorks">
 					<div className="leftContent">
-						<img src="/howtowork.png" alt="" />
+						<Image src="/howtowork.png" alt="" width={600} height={600} sizes="(max-width: 768px) 80vw, 30vw" />
 					</div>
 					<div className="rightContent">
 						<h2>Como funciona?</h2>
@@ -106,7 +117,7 @@ export default function Home() {
 								<a href="/pets" key={index}>
 									<div className="content">
 										<div className="image">
-											<img src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} />
+											<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={440} height={500} sizes="(max-width: 1366px) 18rem, 22rem" />
 										</div>
 
 										<div className="text">
@@ -132,7 +143,7 @@ export default function Home() {
 
 				<div className="maps">
 					<div className="leftContent">
-						<img src="/girllooking.png" alt="" />
+						<Image src="/girllooking.png" alt="" width={600} height={600} sizes="(max-width: 768px) 0px, 30vw" />
 					</div>
 					<div className="rightContent">
 						<h1>Confira animais e abrigos relatados no mapa</h1>
@@ -146,7 +157,7 @@ export default function Home() {
 
 				<div className="petBack">
 					<div className="leftContent">
-						<img src="/smilingbaby.png" alt="" />
+						<Image src="/smilingbaby.png" alt="" width={600} height={600} sizes="(max-width: 768px) 0px, 30vw" />
 					</div>
 					<div className="rightContent">
 						<h2>Tenha seu pet de volta</h2>
@@ -155,11 +166,11 @@ export default function Home() {
 				</div>
 
 				<div className="hotdog">
-					<img src="/hotdog.png" alt="Cachorro Salsicha" />
+					<Image src="/hotdog.png" alt="Cachorro Salsicha" width={700} height={350} sizes="100vw" />
 				</div>
 
 				<div className="painel green">
-					<img src="/littlelogo.png" alt="pet" />
+					<Image src="/littlelogo.png" alt="pet" width={120} height={120} />
 
 					<h1>Faça a Diferença na Vida de um Pet</h1>
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -83,13 +83,13 @@ export default function Home() {
 						</div>
 					</div>
 					<div className="rightContent">
-						<Image src="/dog.png" alt="" width={800} height={800} priority sizes="(max-width: 768px) 0px, 50vw" />
+						<Image src="/dog.png" alt="" width={800} height={800} priority sizes="(max-width: 768px) 0px, 50vw" style={{ marginTop: "-10rem", width: "50rem", height: "auto" }} />
 					</div>
 				</div>
 
 				<div className="howWorks" id="howWorks">
 					<div className="leftContent">
-						<Image src="/howtowork.png" alt="" width={600} height={600} sizes="(max-width: 768px) 80vw, 30vw" />
+						<Image src="/howtowork.png" alt="" width={480} height={480} sizes="(max-width: 768px) 80vw, 30vw" style={{ width: "30rem", height: "auto", marginRight: "10rem" }} />
 					</div>
 					<div className="rightContent">
 						<h2>Como funciona?</h2>
@@ -117,7 +117,7 @@ export default function Home() {
 								<a href="/pets" key={index}>
 									<div className="content">
 										<div className="image">
-											<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={440} height={500} sizes="(max-width: 1366px) 18rem, 22rem" />
+											<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={352} height={400} sizes="(max-width: 1366px) 18rem, 22rem" style={{ width: "22rem", height: "25rem", objectFit: "cover", borderRadius: "15px" }} />
 										</div>
 
 										<div className="text">
@@ -143,7 +143,7 @@ export default function Home() {
 
 				<div className="maps">
 					<div className="leftContent">
-						<Image src="/girllooking.png" alt="" width={600} height={600} sizes="(max-width: 768px) 0px, 30vw" />
+						<Image src="/girllooking.png" alt="" width={500} height={500} sizes="(max-width: 768px) 0px, 30vw" style={{ width: "25rem", height: "auto" }} />
 					</div>
 					<div className="rightContent">
 						<h1>Confira animais e abrigos relatados no mapa</h1>
@@ -157,7 +157,7 @@ export default function Home() {
 
 				<div className="petBack">
 					<div className="leftContent">
-						<Image src="/smilingbaby.png" alt="" width={600} height={600} sizes="(max-width: 768px) 0px, 30vw" />
+						<Image src="/smilingbaby.png" alt="" width={500} height={500} sizes="(max-width: 768px) 0px, 30vw" style={{ width: "25rem", height: "auto" }} />
 					</div>
 					<div className="rightContent">
 						<h2>Tenha seu pet de volta</h2>
@@ -166,11 +166,11 @@ export default function Home() {
 				</div>
 
 				<div className="hotdog">
-					<Image src="/hotdog.png" alt="Cachorro Salsicha" width={700} height={350} sizes="100vw" />
+					<Image src="/hotdog.png" alt="Cachorro Salsicha" width={700} height={350} sizes="100vw" style={{ width: "100%", height: "auto" }} />
 				</div>
 
 				<div className="painel green">
-					<Image src="/littlelogo.png" alt="pet" width={120} height={120} />
+					<Image src="/littlelogo.png" alt="pet" width={100} height={100} style={{ width: "6.25rem", height: "6.25rem" }} />
 
 					<h1>Faça a Diferença na Vida de um Pet</h1>
 

--- a/pages/pets.jsx
+++ b/pages/pets.jsx
@@ -4,6 +4,7 @@ import petServices from "../src/services/pet.services";
 import Navigation from "../src/components/Navigation";
 import Footer from "../src/components/Footer";
 import Head from "next/head";
+import Image from "next/image";
 
 import { getLabelColorBasedOnStatus } from "../src/utils/getLabelColorBasedOnStatus";
 
@@ -101,7 +102,7 @@ const PetsPage = ({ initialPets }) => {
 	const NotFound = () => {
 		return (
 			<div className="not-found">
-				<img src="/not-found.png" width={400} height={400} alt="Not Found" />
+				<Image src="/not-found.png" width={400} height={400} alt="Not Found" sizes="(max-width: 768px) 80vw, 400px" />
 				<button onClick={() => (window.location.href = "/reporte")}>CADASTRAR PET</button>
 			</div>
 		);
@@ -144,7 +145,7 @@ const PetsPage = ({ initialPets }) => {
 							<a href={`/pets/` + pets.slug} key={index}>
 								<div className="content">
 									<div className="image">
-										<img src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} />
+										<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={440} height={500} sizes="(max-width: 1366px) 18rem, 22rem" />
 									</div>
 
 									<div className="text">

--- a/pages/pets.jsx
+++ b/pages/pets.jsx
@@ -145,7 +145,7 @@ const PetsPage = ({ initialPets }) => {
 							<a href={`/pets/` + pets.slug} key={index}>
 								<div className="content">
 									<div className="image">
-										<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={440} height={500} sizes="(max-width: 1366px) 18rem, 22rem" />
+										<Image src={pets.imageURL ? pets.imageURL : "/faind.jpg"} alt={pets.name} width={352} height={400} sizes="(max-width: 1366px) 18rem, 22rem" style={{ width: "22rem", height: "25rem", objectFit: "cover", borderRadius: "15px" }} />
 									</div>
 
 									<div className="text">

--- a/pages/pets/[slug].jsx
+++ b/pages/pets/[slug].jsx
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import Image from "next/image";
 import { toast } from "sonner";
 import Footer from "../../src/components/Footer";
 import Navigation from "../../src/components/Navigation";
@@ -69,7 +70,7 @@ const PetSlugPage = ({ pet }) => {
 						<>
 							<div className="content">
 								<div className="leftContent">
-									<img src={pet.imageURL ? pet.imageURL : "faind.jpg"} alt={pet?.name} />
+									<Image src={pet.imageURL ? pet.imageURL : "/faind.jpg"} alt={pet?.name || "Pet"} width={352} height={400} priority sizes="(max-width: 768px) 90vw, 22rem" />
 								</div>
 
 								<div className="rightContent">

--- a/pages/pets/[slug].jsx
+++ b/pages/pets/[slug].jsx
@@ -70,7 +70,7 @@ const PetSlugPage = ({ pet }) => {
 						<>
 							<div className="content">
 								<div className="leftContent">
-									<Image src={pet.imageURL ? pet.imageURL : "/faind.jpg"} alt={pet?.name || "Pet"} width={352} height={400} priority sizes="(max-width: 768px) 90vw, 22rem" />
+									<Image src={pet.imageURL ? pet.imageURL : "/faind.jpg"} alt={pet?.name || "Pet"} width={352} height={400} priority sizes="(max-width: 768px) 90vw, 22rem" style={{ width: "22rem", height: "25rem", objectFit: "cover", borderRadius: "15px 0 0 15px" }} />
 								</div>
 
 								<div className="rightContent">

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import React from "react";
+import Image from "next/image";
 
 const Navigation = () => {
 	function redirectToHome() {
@@ -9,7 +10,7 @@ const Navigation = () => {
 	return (
 		<NavigationDetails>
 			<a href="/">
-				<img src="/logotipo-100px.png" alt="logo" />
+				<Image src="/logotipo-100px.png" alt="logo" width={400} height={100} priority sizes="(max-width: 768px) 60vw, 25rem" />
 			</a>
 
 			<div className="menu">

--- a/src/services/cep.services.js
+++ b/src/services/cep.services.js
@@ -1,6 +1,8 @@
 async function fetchCEP(cep_value) {
 	try {
-		const response = await fetch(`https://viacep.com.br/ws/${cep_value}/json/`);
+		const response = await fetch(`https://viacep.com.br/ws/${cep_value}/json/`, {
+			next: { revalidate: 86400 },
+		});
 		if (response.status === 200) {
 			return response.json();
 		}

--- a/src/utils/getInfosAndSendToDiscord.js
+++ b/src/utils/getInfosAndSendToDiscord.js
@@ -9,6 +9,7 @@ export const getInfosAndSendToDiscord = (pet) => {
 	}
 
 	fetch(url, {
+		next: { revalidate: 300 },
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({

--- a/src/utils/getReportAndSendToDiscord.js
+++ b/src/utils/getReportAndSendToDiscord.js
@@ -9,6 +9,7 @@ export const getReportAndSendToDiscord = (pet) => {
 	}
 
 	fetch(url, {
+		next: { revalidate: 300 },
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,5 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;500;600;700&display=swap");
-
 :root {
 	--background: #eeeeee;
 	--background-alt: #232634;
@@ -36,10 +34,6 @@ body::-webkit-scrollbar-track {
 body::-webkit-scrollbar-thumb {
 	background-color: var(--green);
 	border-radius: 20px;
-}
-
-* {
-	font-family: "Poppins", sans-serif;
 }
 
 html,


### PR DESCRIPTION
### Motivation
- The project uses Next.js (v16.1.1) with the Pages Router and needs LCP, caching and font-loading improvements without changing business logic.

### Description
- Added `middleware.ts` to set `Cache-Control` headers for static assets and pages using `s-maxage` + `stale-while-revalidate` and long `immutable` caching for images/assets.
- Replaced key `<img>` usages with `next/image` and added `priority` for above-the-fold assets and responsive `sizes` in `pages/index.jsx`, `pages/pets.jsx`, `pages/pets/[slug].jsx`, and `src/components/Navigation.jsx`.
- Enabled modern image formats and broad remote image support in `next.config.js` by adding `formats` and `remotePatterns`.
- Swapped the Google Fonts CSS import for `next/font/google` (`Poppins`) with `display: 'swap'` and applied the font class in `pages/_app.jsx`, while removing the `@import` from `styles/globals.css`.
- Implemented a simple client-side stale-while-revalidate flow for the home pet list using `sessionStorage` hydration + background refresh, and added `next: { revalidate }` hints to applicable `fetch` calls in `src/services/cep.services.js`, `src/utils/getInfosAndSendToDiscord.js` and `src/utils/getReportAndSendToDiscord.js`.

### Testing
- Ran repository inspections (`rg --files`, `rg`), file diffs (`git diff`), and staged/committed the changes with `git commit`, and all commands completed successfully.
- Opened and reviewed modified files (`nl`/`sed`) to verify the diffs and confirmed the code changes were applied without obvious syntax issues.
- Per instructions no build or runtime tests were executed, so no build/test run results are reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a82febd483208196147dc6b6633e)